### PR TITLE
1.  **修正了 `#[expect]` 介绍章节的代码示例错误**：

### DIFF
--- a/src/mod_01_basics.rs
+++ b/src/mod_01_basics.rs
@@ -757,15 +757,15 @@ fn practical_examples() {
 }
 
 // ===========================================
-// 8. Rust 1.78 #[expect(lint)] 属性
+// 8. Rust 1.81 #[expect(lint)] 属性
 // ===========================================
 
-// Rust 1.78 引入了 #[expect(lint)] 属性，这是一个重要的编译器改进
+// Rust 1.81 引入了 #[expect(lint)] 属性，这是一个重要的编译器改进
 // 它允许开发者明确预期某些 lint 警告，从而提供更好的代码维护体验
 // 与 #[allow] 不同，#[expect] 会确保如果预期的警告没有出现，编译器会报错
 
 fn compiler_attributes() {
-    println!("=== Rust 1.78 #[expect(lint)] 属性 ===");
+    println!("=== Rust 1.81 #[expect(lint)] 属性 ===");
 
     // #[expect(lint)] 属性的背景和意义：
     // 1. 显式意图：明确表达对特定 lint 的预期
@@ -779,14 +779,14 @@ fn compiler_attributes() {
     // #[expect(dead_code)] - 预期警告，如果警告消失会报错
 
     // 示例 1: 预期 dead_code 警告
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     fn unused_function() {
         println!("这是一个故意未使用的函数");
     }
 
     // 示例 2: 预期 unused_variables 警告
     fn function_with_unused_variables() {
-        #[allow(unused_variables)]
+        #[expect(unused_variables)]
         let _future_feature = "预留变量";
 
         println!("函数中包含预期的未使用变量");
@@ -794,7 +794,7 @@ fn compiler_attributes() {
 
     // 示例 3: 预期 deprecated 警告
     #[deprecated(since = "1.0.0", note = "使用 new_function 替代")]
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     fn old_function() {
         println!("这是一个已弃用的函数");
     }
@@ -804,12 +804,12 @@ fn compiler_attributes() {
     }
 
     // 演示调用已弃用函数
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     old_function();
 
     // 示例 4: 在模块级别使用 #[expect]
     mod example_module {
-        #![allow(unused_imports)]
+        #![expect(unused_imports)]
 
         use std::collections::HashMap;
         use std::fs::File;
@@ -828,14 +828,14 @@ fn compiler_attributes() {
         let _allowed_variable = "这不会产生警告";
 
         // 使用 #[expect] - 预期警告，有维护保障
-        #[allow(unused_variables)]
+        #[expect(unused_variables)]
         let _expected_variable = "这应该产生警告";
 
         println!("#[expect] 提供了更好的维护保障");
     }
 
     // 示例 6: 多重 lint 预期
-    #[allow(
+    #[expect(
         dead_code,
         unused_variables
     )]
@@ -846,7 +846,7 @@ fn compiler_attributes() {
 
     // 示例 7: 条件性预期警告
     #[cfg(debug_assertions)]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     fn debug_only_function() {
         println!("仅在调试模式下使用的函数");
     }
@@ -863,7 +863,7 @@ fn practical_expect_examples() {
 
     // 场景 1: API 向后兼容性
     mod legacy_api {
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         #[deprecated(since = "2.0.0", note = "使用 new_api() 替代")]
         pub fn old_api() {
             println!("遗留 API 实现");
@@ -875,7 +875,7 @@ fn practical_expect_examples() {
 
         // 在某些情况下，我们可能需要保留旧的 API 调用
         pub fn transition_code() {
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             old_api(); // 临时调用旧 API
             new_api(); // 同时使用新 API
         }
@@ -883,17 +883,17 @@ fn practical_expect_examples() {
 
     // 场景 2: 测试代码中的预期警告
     mod test_utilities {
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         pub fn setup_test_environment() {
             println!("设置测试环境");
         }
 
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         pub fn generate_test_data() -> Vec<i32> {
             vec![1, 2, 3, 4, 5]
         }
 
-        #[allow(unused_variables)]
+        #[expect(unused_variables)]
         pub fn test_placeholder() {
             let _placeholder = "测试占位符";
         }
@@ -901,7 +901,7 @@ fn practical_expect_examples() {
 
     // 场景 3: 条件编译的预期警告
     mod experimental_features {
-        #![allow(dead_code)]
+        #![expect(dead_code)]
 
         pub fn experimental_feature() {
             println!("实验性功能实现");
@@ -911,12 +911,12 @@ fn practical_expect_examples() {
     // 场景 4: 代码生成器的预期警告
     mod generated_code {
         // 在实际应用中，这可能是由代码生成器产生的代码
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         fn generated_placeholder() {
             // 占位符实现
         }
 
-        #[allow(unused_variables)]
+        #[expect(unused_variables)]
         fn generated_with_placeholders() {
             let _future_impl = "预留实现";
         }
@@ -924,7 +924,7 @@ fn practical_expect_examples() {
 
     // 场景 5: 性能优化相关的预期警告
     mod performance_code {
-        #[allow(clippy::modulo_one)]
+        #[expect(clippy::modulo_one)]
         pub fn optimized_calculation() {
             // 某些性能优化可能会触发 lint
             let _result = 100 % 1; // 故意的模1运算

--- a/src/mod_02_ownership.rs
+++ b/src/mod_02_ownership.rs
@@ -92,6 +92,41 @@ fn ownership_rules() {
     // - 复制：用于小的栈分配数据，复制成本低廉
 
     println!();
+
+    // ===========================================
+    // 如何辨别 Copy 还是 Move
+    // ===========================================
+    // 很多初学者对于变量赋值时到底是发生 Copy 还是 Move 感到困惑
+    // 这里有三种主要的方法来辨别：
+
+    // 方法 1：查阅文档（最权威）
+    // 查看该类型的文档，看它是否实现了 Copy trait。
+    // 一般来说，标量类型（Scalar Types）都是 Copy 的。
+    // 例如：i32, bool, char, f64 都实现了 Copy
+    // String, Vec<T> 没有实现 Copy
+
+    // 方法 2：观察编译器行为（最直接）
+    // 尝试在赋值后继续使用原变量。如果编译报错 "borrow of moved value"，则是 Move 语义。
+    println!("--- 辨别 Copy vs Move ---");
+    let s = String::from("test");
+    let _s_copy = s;
+    // println!("{}", s); // 如果这行代码报错，说明是 Move
+
+    let i = 10;
+    let _i_copy = i;
+    println!("{}", i); // 这行代码正常运行，说明是 Copy
+
+    // 方法 3：代码检测（编程方式）
+    // 我们可以编写一个辅助函数来在编译时检查类型是否实现了 Copy
+    fn is_copy<T: Copy>() {
+        println!("{} is Copy", std::any::type_name::<T>());
+    }
+
+    // is_copy::<String>(); // 这行代码会导致编译错误，因为 String 没有实现 Copy
+    is_copy::<i32>();       // 编译通过
+    is_copy::<bool>();      // 编译通过
+
+    println!("------------------------");
 }
 
 // ===========================================

--- a/src/mod_02_ownership.rs
+++ b/src/mod_02_ownership.rs
@@ -368,6 +368,32 @@ fn slices() {
     // 3. 提供了灵活的数据访问方式
     // 4. 编译时和运行时的边界检查
 
+
+    // 切片在多线程中的使用：
+    // 用户常问：我能把切片传递给线程吗？
+    // 答案：不能直接传给 std::thread::spawn，但可以使用 std::thread::scope。
+    
+    // 1. std::thread::spawn 的限制
+    // spawn 要求闭包和其捕获的数据具有 'static 生命周期。
+    // 切片通常是对局部数据的引用，生命周期较短，不满足 'static 要求。
+    // 试图这样做会导致编译错误："borrowed value does not live long enough"。
+
+    // 2. 解决方案：std::thread::scope (Rust 1.63+)
+    // 作用域线程保证线程在作用域结束前完成，因此可以安全地借用局部变量（包括切片）。
+    
+    /*
+    let numbers = vec![1, 2, 3];
+    let slice = &numbers[..];
+
+    std::thread::scope(|s| {
+        s.spawn(|| {
+            // 这里可以安全地使用 slice，因为 scope 保证线程
+            // 会在 numbers 被销毁前结束
+            println!("在线程中使用切片: {:?}", slice);
+        });
+    });
+    */
+
     // 数组切片
     let a = [1, 2, 3, 4, 5];
     let slice = &a[1..3]; // [2, 3]
@@ -426,6 +452,35 @@ fn lifetimes() {
     // 3. 如果有多个输入生命周期参数，但其中一个是 &self 或 &mut self，
     //    那么 self 的生命周期被赋予所有输出生命周期参数
 
+    // 生命周期省略规则详解及示例：
+
+    // 规则 1：为每个引用参数分配生命周期
+    // 为了通过编译，编译器会为每个引用参数自动添加生命周期参数
+    // 原代码：fn foo(x: &i32)
+    // 编译器推断：fn foo<'a>(x: &'a i32)
+    // 原代码：fn bar(x: &i32, y: &i32)
+    // 编译器推断：fn bar<'a, 'b>(x: &'a i32, y: &'b i32)
+
+    // 规则 2：输入生命周期赋给输出
+    // 如果只有一个输入生命周期参数，那么它被赋予所有输出生命周期参数
+    // 原代码：fn return_x(x: &i32) -> &i32
+    // 编译器推断：fn return_x<'a>(x: &'a i32) -> &'a i32
+    // 这意味着返回值的生命周期与参数 x 的生命周期相同
+
+    // 规则 3：方法中的生命周期
+    // 如果有多个输入生命周期参数，但其中一个是 &self 或 &mut self，
+    // 那么 self 的生命周期被赋予所有输出生命周期参数
+    // 原代码：
+    // impl Struct {
+    //     fn method(&self, x: &str) -> &str { ... }
+    // }
+    // 编译器推断：
+    // impl Struct {
+    //     fn method<'a, 'b>(&'a self, x: &'b str) -> &'a str { ... }
+    // }
+    // 这意味着方法的返回值生命周期与 self（即对象实例）的生命周期相同，
+    // 而不是参数 x 的生命周期。这是这是非常合理的默认行为。
+
     // 生命周期的实际应用：
     let novel = String::from("Call me Ishmael. Some years ago...");
     let first_sentence = novel.split('.').next().unwrap();
@@ -468,6 +523,46 @@ fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
 #[derive(Debug)]
 struct ImportantExcerpt<'a> {
     part: &'a str,
+}
+
+// 结构体中的多重引用示例
+// 1. 多个字段共享同一个生命周期 'a
+// 这意味着 x 和 y 的生命周期都必须至少覆盖 'a
+// 且 'a 不能超过它们两者中较短的那个生命周期
+#[derive(Debug)]
+struct DoubleRef<'a> {
+    x: &'a str,
+    y: &'a str,
+}
+
+// 2. 多个字段拥有不同的生命周期 'a 和 'b
+// 这里 x 和 y 的生命周期是独立的，互相不影响
+// 当引用的来源不同且生命周期差异较大时，这种方式更灵活
+#[derive(Debug)]
+struct DiffRef<'a, 'b> {
+    x: &'a str,
+    y: &'b str,
+}
+
+fn multiple_refs_demo() {
+    let s1 = String::from("long lived");
+    let r1;
+    {
+        let s2 = String::from("short");
+        
+        // 使用 DiffRef，分别引用 s1 和 s2
+        // 这是允许的，因为 'a 和 'b 是独立的
+        let diff = DiffRef { x: &s1, y: &s2 }; 
+        println!("DiffRef: {:?}", diff);
+
+        // 如果使用 DoubleRef，所有字段必须满足同一个生命周期 'a
+        // 这里 'a 被推断为较短的 s2 的生命周期
+        let same = DoubleRef { x: &s1, y: &s2 };
+        println!("DoubleRef: {:?}", same);
+        
+        // 当离开此作用域，s2 被释放，same 也失效
+        // 但 s1 还是有效的，如果是 DiffRef 且只使用了 x 字段，可能还有机会继续使用（取决于具体用法）
+    }
 }
 
 // ===========================================

--- a/src/mod_02_ownership.rs
+++ b/src/mod_02_ownership.rs
@@ -546,7 +546,6 @@ struct DiffRef<'a, 'b> {
 
 fn multiple_refs_demo() {
     let s1 = String::from("long lived");
-    let r1;
     {
         let s2 = String::from("short");
         


### PR DESCRIPTION
    该章节（第 8 部分）旨在介绍 `#[expect]` 属性，但所有的示例代码（示例 1-4, 6-7 以及实际应用场景）之前都错误地使用了 `#[allow]`。

2.  **更正了版本信息**： 原文档称 `#[expect]` 是在 Rust 1.78 引入的。实际上，它是 Rust 1.81 稳定版才发布的特性。